### PR TITLE
PMCS-23233 Make SDK changes to deprecate four APIs.

### DIFF
--- a/docs/Host/Grant-HypSecurityGroupEgress.md
+++ b/docs/Host/Grant-HypSecurityGroupEgress.md
@@ -10,6 +10,7 @@ Grant-HypSecurityGroupEgress [-LiteralPath] <String> -IPRange <String[]> -Protoc
 ```
 
 ## Detailed Description
+This cmdlet is deprecated. \
 Adding an egress rule permits network traffic from instances within the security group to pass to one or more destination CIDR IP address ranges or security groups.
 
 

--- a/docs/Host/Grant-HypSecurityGroupIngress.md
+++ b/docs/Host/Grant-HypSecurityGroupIngress.md
@@ -10,6 +10,7 @@ Grant-HypSecurityGroupIngress [-LiteralPath] <String> -IPRange <String[]> -Proto
 ```
 
 ## Detailed Description
+This cmdlet is deprecated. \
 Adding an egress rule permits network traffic from source CIDR IP address ranges or security groups to pass to instances within a security group.
 
 

--- a/docs/Host/Revoke-HypSecurityGroupEgress.md
+++ b/docs/Host/Revoke-HypSecurityGroupEgress.md
@@ -10,6 +10,7 @@ Revoke-HypSecurityGroupEgress [-LiteralPath] <String> -IPRange <String[]> -Proto
 ```
 
 ## Detailed Description
+This cmdlet is deprecated. \
 To remove a rule, specify parameters matching an existing rule's values.
 
 

--- a/docs/Host/Revoke-HypSecurityGroupIngress.md
+++ b/docs/Host/Revoke-HypSecurityGroupIngress.md
@@ -10,6 +10,7 @@ Revoke-HypSecurityGroupIngress [-LiteralPath] <String> -IPRange <String[]> -Prot
 ```
 
 ## Detailed Description
+This cmdlet is deprecated. \
 To remove a rule, specify parameters matching an existing rule's values.
 
 


### PR DESCRIPTION
The following four commands are required to be declared as deprecated in the on-prem CVAD SDK and CVADS SDK. These commands are specific to AWS cannot be used in Cloud or on-prem, except for the customers using AWS on LTSR.

The four commands are: 
- Revoke-HypSecurityGroupIngress
- Revoke-HypSecurityGroupEgress
- Grant-HypSecuritygroupegress
- Grant-HypSecurityGroupIngress